### PR TITLE
call the dplyr::count.data.frame() method if it exists

### DIFF
--- a/R/tally.R
+++ b/R/tally.R
@@ -375,11 +375,18 @@ count <- function(x, ...) {
   UseMethod("count")
 }
 
+ns_dplyr <- rlang::ns_env("dplyr")
+
 #' @export
 count.data.frame <-
   function(
     x, ...) {
-    dplyr::count(x, ...)
+
+    if (exists("count.data.frame", ns_dplyr)) {
+      get("count.data.frame", ns_dplyr)(x, ...)
+    } else {
+      dplyr::count(x, ...)
+    }
   }
 
 #' @export


### PR DESCRIPTION
closes #36

This is a workaround for #36 for the interim (until now and when dplyr 1.0.3 is released) which should work with previous versions of dplyr as well as the next (1.0.3). 

When `dplyr` is released, I believe then you can depend on `dplyr (>= 1.0.3)` in the `DESCRIPTION`, remove your generic, and then implement a method, probably not for `.default` though. 